### PR TITLE
bugfix: de-tensorized and fix index issues

### DIFF
--- a/QCR_PubMedCLIP/main/test.py
+++ b/QCR_PubMedCLIP/main/test.py
@@ -2,7 +2,7 @@
 
 #-------------------------------------------------------------------------------
 # Name:         train
-# Description:  
+# Description:
 # Author:       Boliu.Kelvin, Sedigheh Eslami
 #-------------------------------------------------------------------------------
 import os
@@ -10,6 +10,7 @@ import time
 import torch
 from utils import utils
 from datetime import datetime
+from pathlib import Path
 import torch.nn as nn
 from torch.optim import lr_scheduler
 from torch.utils.tensorboard import SummaryWriter
@@ -17,14 +18,15 @@ import pandas as pd
 
 
 def compute_score_with_logits(logits, labels):
+    # batch_open_score_temp, open_logits = compute_score_with_logits(preds_open, a_open.data)
     func = torch.nn.Softmax(dim=1)
     logits = func(logits)
     logits = torch.max(logits, 1)[1].data  # argmax
+    print('compute_score_with_logits, logits shape: ', logits.shape)
     one_hots = torch.zeros(*labels.size()).to(logits.device)
     one_hots.scatter_(1, logits.view(-1, 1), 1)
     scores = (one_hots * labels)
     return scores, logits
-
 
 def get_time_stamp():
     ct = time.time()
@@ -33,32 +35,57 @@ def get_time_stamp():
     data_secs = (ct - int(ct)) * 1000
     time_stamp = "%s.%03d" % (data_head, data_secs)
     return time_stamp
+
 # Train phase
 def test(cfg, model, question_model, eval_loader, n_unique_close, device, s_opt=None, s_epoch=0):
-    model = model.to(device)
+    model = model.to(device)  # BAN_model
     question_model = question_model.to(device)
     utils.create_dir(cfg.TEST.RESULT_DIR)
 
     # Evaluation
-    eval_score, open_score, close_score = evaluate_classifier(model,question_model, eval_loader, cfg, n_unique_close, device, cfg.TEST.RESULT_DIR)
+    eval_score, open_score, close_score = evaluate_classifier(model, question_model, eval_loader,
+                                                              cfg, n_unique_close, device,
+                                                              cfg.TEST.RESULT_DIR)
 
-        
+
+def load_pickle(fp: str):
+    import pickle
+    with open(fp, 'rb') as f:
+        return pickle.load(f)
+
+
 # Evaluation
-def evaluate_classifier(model,pretrained_model, dataloader, cfg, n_unique_close, device, result_dir):
+def evaluate_classifier(model, pretrained_model, dataloader, cfg, n_unique_close, device,
+                        result_dir):
     score = 0
     total = 0
-    open_ended = 0. #'OPEN'
+    open_ended = 0.  #'OPEN'
     score_open = 0.
 
-    closed_ended = 0. #'CLOSED'
+    closed_ended = 0.  #'CLOSED'
     score_close = 0.
     model.eval()
-    
-    correct_results = {"image_name": [], "question": [], "answer": [], "answer_type": [], "predicted_answer_type": []}
-    incorrect_results = {"image_name": [], "question": [], "answer": [], "answer_type": [], "predicted_answer": [], "predicted_answer_type": []}
-    
+
+    correct_results = {
+        "image_name": [],
+        "question": [],
+        "answer": [],
+        "predicted_answer": [],
+        "answer_type": [],
+        "predicted_answer_type": []
+    }
+    incorrect_results = {
+        "image_name": [],
+        "question": [],
+        "answer": [],
+        "predicted_answer": [],
+        "answer_type": [],
+        "predicted_answer_type": []
+    }
+    q_img = []
     with torch.no_grad():
-        for i,(v, q, a,answer_type, question_type, phrase_type, answer_target, image_name, question_text, answer_text) in enumerate(dataloader):
+        for i, (v, q, a, answer_type, question_type, phrase_type, answer_target, image_name,
+                question_text, answer_text) in enumerate(dataloader):
 
             if cfg.TRAIN.VISION.MAML:
                 v[0] = v[0].reshape(v[0].shape[0], 84, 84).unsqueeze(1)
@@ -74,27 +101,39 @@ def evaluate_classifier(model,pretrained_model, dataloader, cfg, n_unique_close,
                 v[2] = v[2].to(device)
             if cfg.TRAIN.VISION.OTHER_MODEL:
                 v = v.to(device)
-            
+
             q[0] = q[0].to(device)
             if cfg.TRAIN.QUESTION.CLIP:
                 q[1] = q[1].to(device)
             a = a.to(device)
 
             if cfg.TRAIN.VISION.AUTOENCODER:
-                last_output_close, last_output_open, a_close, a_open, decoder, indexs_open, indexs_close = model.forward_classify(v, q, a, pretrained_model, n_unique_close)
+                last_output_close, last_output_open, a_close, a_open, decoder, indexs_open, indexs_close = model.forward_classify(
+                    v, q, a, pretrained_model, n_unique_close)
             else:
-                last_output_close, last_output_open, a_close, a_open, indexs_open, indexs_close = model.forward_classify(v, q, a, pretrained_model, n_unique_close)
+                last_output_close, last_output_open, a_close, a_open, indexs_open, indexs_close = model.forward_classify(
+                    v, q, a, pretrained_model, n_unique_close)
+            # self.close_classifier = SimpleClassifier(cfg.TRAIN.QUESTION.CLS_HID_DIM, cfg.TRAIN.QUESTION.CLS_HID_DIM * 2, dataset.num_close_candidates, cfg)
+            # self.open_classifier = SimpleClassifier(cfg.TRAIN.QUESTION.CLS_HID_DIM, cfg.TRAIN.QUESTION.CLS_HID_DIM * 2, dataset.num_open_candidates, cfg)
 
             preds_close, preds_open = model.classify(last_output_close, last_output_open)
-            
+            print("evaluate_classifier, preds_close shape: ",
+                  preds_close.shape)  # torch.Size([5, 56])
+            print("evaluate_classifier, preds_open shape: ",
+                  preds_open.shape)  # torch.Size([3, 431])
+
             batch_close_score = 0.
             batch_open_score = 0.
             if preds_close.shape[0] != 0:
-                batch_close_score_temp, close_logits = compute_score_with_logits(preds_close, a_close.data)
+                # preds_close: prediction
+                # a_close.data: gold answers, 1-hot
+                batch_close_score_temp, close_logits = compute_score_with_logits(
+                    preds_close, a_close.data)
                 close_correct = (batch_close_score_temp == 1).nonzero(as_tuple=True)[0].tolist()
                 batch_close_score = batch_close_score_temp.sum()
-            if preds_open.shape[0] != 0: 
-                batch_open_score_temp, open_logits = compute_score_with_logits(preds_open, a_open.data)
+            if preds_open.shape[0] != 0:
+                batch_open_score_temp, open_logits = compute_score_with_logits(
+                    preds_open, a_open.data)
                 open_correct = (batch_open_score_temp == 1).nonzero(as_tuple=True)[0].tolist()
                 batch_open_score = batch_open_score_temp.sum()
 
@@ -102,61 +141,109 @@ def evaluate_classifier(model,pretrained_model, dataloader, cfg, n_unique_close,
 
             size = q[0].shape[0]
             total += size  # batch number
-            
+
             open_ended += preds_open.shape[0]
             score_open += batch_open_score
 
             closed_ended += preds_close.shape[0]
             score_close += batch_close_score
-
+            # indexes_{type} is the indexes inside the batch that are {type}-ended
+            # indexes_close: [0, 1, 3, 4, 5, 7]
+            # indexes_open: [2, 6]
             assert len(indexs_close) + len(indexs_open) == len(image_name)
             assert len(close_correct) + len(open_correct) <= len(image_name)  # batch size
 
+            # PubMedCLIP/QCR_PubMedCLIP/data/data_rad/cache/close_label2ans.pkl
+            # PubMedCLIP/QCR_PubMedCLIP/data/data_rad/cache/open_label2ans.pkl
+
+            cache_root = './data/data_rad/cache'
+            close_l2a = load_pickle(Path(cache_root) / 'close_label2ans.pkl')
+            open_l2a = load_pickle(Path(cache_root) / 'open_label2ans.pkl')
+
             close_incorrect = [i for i in range(len(indexs_close)) if i not in close_correct]
             open_incorrect = [i for i in range(len(indexs_open)) if i not in open_correct]
+            # print("close")
+            # print("\tindices", indexs_close)
+            # print("\tcorrect: ", close_correct)
+            # print("\tincorrect: ", close_incorrect)
+            # print("open")
+            # print("\tindices", indexs_open)
+            # print("\tcorrect: ", open_correct)
+            # print("\tincorrect: ", open_incorrect)
+
+            # Bugfix
+            # close
+            #         (batch) indices [0, 1, 2, 6]
+            #         correct:  [2, 3]      -> [2, 6]
+            #         incorrect:  [0, 1]    -> [0, 1]
+            # open
+            #         (batch) indices [3, 4, 5, 7]
+            #         correct:  [0, 2, 3] -> [3, 5, 7]
+            #         incorrect:  [1]     -> [4]
+
             for i in close_correct:
                 ind = indexs_close[i]
+
+                pred_label = close_logits[i].cpu().item()
+                pred_answer = close_l2a[pred_label]
+                correct_results["predicted_answer"].append(pred_answer)
                 correct_results["image_name"].append(image_name[ind])
                 correct_results["question"].append(question_text[ind])
                 correct_results["answer"].append(answer_text[ind])
                 correct_results["predicted_answer_type"].append("CLOSED")
                 correct_results["answer_type"].append(answer_type[ind])
-            for ind in close_incorrect:
+            for i in close_incorrect:
+                ind = indexs_close[i]
+                pred_label = close_logits[i].cpu().item()
+                pred_answer = close_l2a[pred_label]
                 incorrect_results["image_name"].append(image_name[ind])
                 incorrect_results["question"].append(question_text[ind])
                 incorrect_results["answer"].append(answer_text[ind])
-                incorrect_results["predicted_answer"].append(close_logits[ind].cpu())
+                incorrect_results["predicted_answer"].append(pred_answer)
                 incorrect_results["predicted_answer_type"].append("CLOSED")
                 incorrect_results["answer_type"].append(answer_type[ind])
             for i in open_correct:
                 ind = indexs_open[i]
+
+                pred_label = open_logits[i].cpu().item()
+                pred_answer = open_l2a[pred_label]
+
                 correct_results["image_name"].append(image_name[ind])
                 correct_results["question"].append(question_text[ind])
                 correct_results["answer"].append(answer_text[ind])
+                correct_results["predicted_answer"].append(pred_answer)
                 correct_results["predicted_answer_type"].append("OPEN")
                 correct_results["answer_type"].append(answer_type[ind])
-            for ind in open_incorrect:
+
+            for i in open_incorrect:
+                ind = indexs_open[i]
+
+                pred_label = open_logits[i].cpu().item()
+                pred_answer = open_l2a[pred_label]
                 incorrect_results["image_name"].append(image_name[ind])
                 incorrect_results["question"].append(question_text[ind])
                 incorrect_results["answer"].append(answer_text[ind])
-                incorrect_results["predicted_answer"].append(open_logits[ind].cpu())
+                incorrect_results["predicted_answer"].append(pred_answer)
                 incorrect_results["predicted_answer_type"].append("OPEN")
                 incorrect_results["answer_type"].append(answer_type[ind])
 
+
+
     try:
-        score = 100* score / total
+        score = 100 * score / total
     except ZeroDivisionError:
         score = 0
     try:
-        open_score = 100* score_open/ open_ended
+        open_score = 100 * score_open / open_ended
     except ZeroDivisionError:
         open_score = 0
     try:
-        close_score = 100* score_close/ closed_ended
+        close_score = 100 * score_close / closed_ended
     except ZeroDivisionError:
         close_score = 0
     print(total, open_ended, closed_ended)
-    print('[Validate] Val_Acc:{:.6f}%  |  Open_ACC:{:.6f}%   |  Close_ACC:{:.6f}%' .format(score,open_score,close_score))
+    print('[Validate] Val_Acc:{:.6f}%  |  Open_ACC:{:.6f}%   |  Close_ACC:{:.6f}%'.format(
+        score, open_score, close_score))
     df = pd.DataFrame(correct_results)
     df.to_csv(f"{result_dir}/correct_predictions.csv", index=False)
     inc_df = pd.DataFrame(incorrect_results)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The `correct_predictions.csv` and `incorrect_predictions.csv` should supposedly contain `qid`. 
They do not, so I try to map back the `qid` using `image_name` and `question_text` in  a batch (which is a valid approach because in `testset.json` the 2 keys do form a composite unique key).  
However I find these 2 files have overlap in the mapped-back `qid`.  
Upon reading the codes, I find that the 4 for loops in `test.py` from #L117 to #L144 have indexing issues (should use batch index `ind` to index elements in the batch loaders; use `i` for indexing open and close logits,  the original codes kind of mix them up I guess). 


## Related Issue
- None

## Motivation and Context
- The original prediction files have tensors inside; do not provide the decoded answers. 
- The original prediction files have indexing issues. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is verified that with the `test.py` in this PR, the 2 correction files can map to non-overlap `qid` sets that can union to the full testset. 
```python

trainset = load_json(Path(data_dir)/"trainset.json") 
testset = load_json(Path(data_dir)/"testset.json")
trainset = to_dataframe(trainset)
testset = to_dataframe(testset) 

correct_df = pd.read_csv(Path(result_dir)/'correct_predictions.csv')
incorrect_df = pd.read_csv(Path(result_dir)/'incorrect_predictions.csv') 

# need to use question + image_name to map back
def qid_map(r: pd.Series):
    q = r['question']
    img = r['image_name']
    assert len(testset[(testset['question'] == q) & (testset['image_name'] == img)]) == 1
    return testset[(testset['question'] == q) & (testset['image_name'] == img)]['qid'].values[0]

qtype_map = testset[['qid', 'question_type']].set_index('qid').to_dict()['question_type']
for df in [correct_df, incorrect_df]:
    df['qid'] = df.apply(qid_map, axis=1)
    df['question_type'] = df['qid'].map(qtype_map)
# map the answer back to trainset.json, testset.json as inference results
# merge correct and incorrect
correct_df['correct'] = True
incorrect_df['correct'] = False
inference = pd.concat([correct_df, incorrect_df], axis=0)
# use question + image_name to map back to testset
correct_df.shape, incorrect_df.shape, inference.shape
# check if there is any overlap
correct_qids = set(correct_df['qid'].values)
incorrect_qids = set(incorrect_df['qid'].values)

# union 
union = correct_qids.union(incorrect_qids)
print(len(union))
# intersection
intersection = correct_qids.intersection(incorrect_qids)
print(len(intersection))
```
## Screenshots (if appropriate):
<img width="794" alt="image" src="https://user-images.githubusercontent.com/58811089/235844914-1554c361-3b48-492c-aecc-a6f772048063.png">
